### PR TITLE
Add Nanvix CI Workflow

### DIFF
--- a/.github/workflows/ci-nanvix.yml
+++ b/.github/workflows/ci-nanvix.yml
@@ -1,0 +1,139 @@
+name: ci-nanvix
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
+  push:
+    branches:
+      - "nanvix/*"
+  pull_request:
+    branches:
+      - "nanvix/*"
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  discover-artifacts:
+    runs-on: self-hosted
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - name: Discover Nanvix .tar.bz2 assets
+        id: generate-matrix
+        env:
+          API_URL: https://api.github.com/repos/nanvix/nanvix/releases/tags/latest
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          response=$(curl -fsSL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${GH_TOKEN}" -H "X-GitHub-Api-Version: 2022-11-28" "$API_URL")
+          tarballs=$(echo "$response" | jq '[.assets[] | select(.browser_download_url | endswith(".tar.bz2")) | {artifact_name: .name, artifact_url: .browser_download_url}]')
+          count=$(echo "$tarballs" | jq 'length')
+          if [[ "$count" -eq 0 ]]; then
+            echo "::error::No .tar.bz2 assets were found in the latest Nanvix release."
+            exit 1
+          fi
+          matrix=$(echo "$tarballs" | jq -c '{include: .}')
+          echo "Matrix definition: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: discover-artifacts
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-artifacts.outputs.matrix) }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache Rust target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-nanvix-${{ matrix.artifact_name }}-${{ github.ref }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nanvix-${{ matrix.artifact_name }}-
+
+      - name: Download Nanvix artifact ${{ matrix.artifact_name }}
+        env:
+          ARTIFACT_DIR: ${{ github.workspace }}/nanvix-artifacts
+          ARTIFACT_URL: ${{ matrix.artifact_url }}
+          ARTIFACT_NAME: ${{ matrix.artifact_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$ARTIFACT_DIR"
+          DEST="$ARTIFACT_DIR/$ARTIFACT_NAME"
+          echo "Downloading $ARTIFACT_URL"
+          curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/octet-stream" "$ARTIFACT_URL" -o "$DEST"
+          if [[ ! -s "$DEST" ]]; then
+            echo "::error::Failed to download $ARTIFACT_URL"
+            exit 1
+          fi
+
+      - name: Extract Nanvix artifact ${{ matrix.artifact_name }}
+        env:
+          ARTIFACT_DIR: ${{ github.workspace }}/nanvix-artifacts
+          ARTIFACT_NAME: ${{ matrix.artifact_name }}
+        run: |
+          set -euo pipefail
+          SRC="$ARTIFACT_DIR/$ARTIFACT_NAME"
+          EXTRACT_DIR="$ARTIFACT_DIR/extracted/${ARTIFACT_NAME//.tar.bz2/}"
+          rm -rf "$EXTRACT_DIR"
+          mkdir -p "$EXTRACT_DIR"
+          tar -xjf "$SRC" -C "$EXTRACT_DIR"
+          echo "EXTRACTED_NANVIX_HOME=$EXTRACT_DIR" >> "$GITHUB_ENV"
+          echo "Using extracted Nanvix artifacts from $EXTRACT_DIR"
+
+      - name: Build rusty_v8 for Nanvix
+        env:
+          LOG_DIR: ${{ github.workspace }}/ci-logs
+        run: |
+          set -euo pipefail
+          : "${EXTRACTED_NANVIX_HOME:?Missing extracted artifact path}"
+          LOCAL_TOOLCHAIN="$HOME/toolchain"
+          if [[ ! -d "$LOCAL_TOOLCHAIN" ]]; then
+            echo "::error::Local Nanvix toolchain not found at $LOCAL_TOOLCHAIN"
+            exit 1
+          fi
+          mkdir -p "$LOG_DIR"
+          LOG_FILE="$LOG_DIR/make-build-${{ matrix.artifact_name }}.log"
+          NANVIX_HOME="${EXTRACTED_NANVIX_HOME}" \
+          NANVIX_TOOLCHAIN="$LOCAL_TOOLCHAIN" \
+          DOCKER=no \
+          VERBOSE=yes \
+          make all |& tee "$LOG_FILE"
+          echo "Make build logs saved to $LOG_FILE"
+
+      - name: Install rusty_v8 artifacts
+        run: |
+          set -euo pipefail
+          : "${EXTRACTED_NANVIX_HOME:?Missing extracted artifact path}"
+          LOCAL_TOOLCHAIN="$HOME/toolchain"
+          if [[ ! -d "$LOCAL_TOOLCHAIN" ]]; then
+            echo "::error::Local Nanvix toolchain not found at $LOCAL_TOOLCHAIN"
+            exit 1
+          fi
+          NANVIX_HOME="${EXTRACTED_NANVIX_HOME}" \
+          NANVIX_TOOLCHAIN="$LOCAL_TOOLCHAIN" \
+          DOCKER=no \
+          VERBOSE=yes \
+          make install-rusty_v8
+
+      - name: Upload build artifacts and logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rusty_v8-nanvix-build-${{ matrix.artifact_name }}
+          path: |
+            ci-logs
+            dist
+          if-no-files-found: warn


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow, `ci-nanvix`, to automate continuous integration for Nanvix-related branches. The workflow discovers Nanvix release artifacts, downloads and extracts them, builds the `rusty_v8` project using a local Nanvix toolchain, and uploads build artifacts and logs. This setup streamlines CI for Nanvix and ensures builds are reproducible and well-logged.

**New CI workflow for Nanvix:**

* Added `.github/workflows/ci-nanvix.yml` to automate builds for `nanvix/*` branches, triggered by pushes, pull requests, manual dispatch, and scheduled runs.

**Artifact discovery and handling:**

* Implements a job to discover `.tar.bz2` assets from the latest Nanvix release using GitHub API, and sets up a build matrix for parallel processing.
* Downloads and extracts Nanvix artifacts for each matrix entry, ensuring the correct environment for builds.

**Build and caching improvements:**

* Builds `rusty_v8` for Nanvix using a local toolchain, with verbose logging and error handling for missing toolchain or artifacts.
* Caches the Rust target directory to speed up subsequent builds and reduce redundant compilation. (