### PR TITLE
Install Target for Makefile

### DIFF
--- a/.github/workflows/ci-nanvix.yml
+++ b/.github/workflows/ci-nanvix.yml
@@ -113,7 +113,7 @@ jobs:
           make all |& tee "$LOG_FILE"
           echo "Make build logs saved to $LOG_FILE"
 
-      - name: Install rusty_v8 artifacts
+      - name: Install Artifacts
         run: |
           set -euo pipefail
           : "${EXTRACTED_NANVIX_HOME:?Missing extracted artifact path}"
@@ -126,7 +126,7 @@ jobs:
           NANVIX_TOOLCHAIN="$LOCAL_TOOLCHAIN" \
           DOCKER=no \
           VERBOSE=yes \
-          make install-rusty_v8
+          make install
 
       - name: Upload build artifacts and logs
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -113,18 +113,21 @@ RMDIR := rm -rf
 
 # Directory where artifacts are installed.
 INSTALL_DIR := dist/nanvix
+INSTALL_LIB_DIR := $(INSTALL_DIR)/lib
+INSTALL_BIN_DIR := $(INSTALL_DIR)/bin
+INSTALL_ETC_DIR := $(INSTALL_DIR)/etc
 
 # Actual build artifacts.
 RUSTY_V8_LIB := $(TARGET_DIR)/gn_out/obj/librusty_v8.a
 BINDING_FILE := $(TARGET_DIR)/gn_out/src_binding.rs
-HELLO_NANVIX_BINARY := $(TARGET_DIR)/examples/hello_nanvix
+HELLO_NANVIX_BINARY := $(TARGET_DIR)/examples/hello_nanvix.elf
 
 #===================================================================================================
 # Build Targets
 #===================================================================================================
 
 # Declare phony targets.
-.PHONY: all all-rusty_v8 all-hello_nanvix install-rusty_v8 clean clean-rusty_v8 clean-hello_nanvix help
+.PHONY: all all-rusty_v8 all-hello_nanvix install install-rusty_v8 install-hello_nanvix clean clean-rusty_v8 clean-hello_nanvix help
 
 # Validate that cargo is available.
 ifeq ($(shell command -v cargo 2>/dev/null),)
@@ -138,7 +141,9 @@ help:
 	$(Q)echo "  all                 Build all V8 projects for Nanvix"
 	$(Q)echo "  all-rusty_v8        Build prebuilt static library"
 	$(Q)echo "  all-hello_nanvix    Build hello_nanvix example"
+	$(Q)echo "  install             Install all artifacts"
 	$(Q)echo "  install-rusty_v8    Install artifacts to dist directory"
+	$(Q)echo "  install-hello_nanvix Install hello_nanvix example"
 	$(Q)echo "  clean               Clean all build artifacts"
 	$(Q)echo "  clean-rusty_v8      Clean rusty_v8 build artifacts"
 	$(Q)echo "  clean-hello_nanvix  Clean hello_nanvix build artifacts"
@@ -170,17 +175,30 @@ all-rusty_v8:
 	$(Q)$(CARGO_BUILD_CMD)
 	$(Q)echo "✓ rusty_v8 library built successfully"
 
+# Installs all artifacts
+install: install-rusty_v8 install-hello_nanvix
+	$(Q)echo "✓ All artifacts installed under $(INSTALL_DIR)"
+
 # Installs rusty_v8 artifacts to dist directory
-install-rusty_v8: $(RUSTY_V8_LIB) $(BINDING_FILE) $(INSTALL_DIR)
+install-rusty_v8: all-rusty_v8 $(INSTALL_DIR)
 	$(Q)echo "=== Installing rusty_v8 artifacts ==="
-	$(Q)echo "Copying static library to $(INSTALL_DIR)..."
+	$(Q)$(MKDIR) "$(INSTALL_LIB_DIR)" "$(INSTALL_ETC_DIR)"
+	$(Q)echo "Copying static library to $(INSTALL_LIB_DIR)..."
 	$(Q)test -f "$(RUSTY_V8_LIB)" || (echo "Error: $(RUSTY_V8_LIB) not found" && exit 1)
-	$(Q)$(CP) "$(RUSTY_V8_LIB)" "$(INSTALL_DIR)/"
-	$(Q)echo "Copying binding file to $(INSTALL_DIR)..."
+	$(Q)$(CP) "$(RUSTY_V8_LIB)" "$(INSTALL_LIB_DIR)/"
+	$(Q)echo "Copying binding file to $(INSTALL_ETC_DIR)..."
 	$(Q)test -f "$(BINDING_FILE)" || (echo "Error: $(BINDING_FILE) not found" && exit 1)
-	$(Q)$(CP) "$(BINDING_FILE)" "$(INSTALL_DIR)/"
-	$(Q)echo "✓ Prebuilt static library created at $(INSTALL_DIR)/librusty_v8.a"
-	$(Q)echo "✓ Binding file created at $(INSTALL_DIR)/src_binding.rs"
+	$(Q)$(CP) "$(BINDING_FILE)" "$(INSTALL_ETC_DIR)/"
+	$(Q)echo "✓ Prebuilt static library created at $(INSTALL_LIB_DIR)/librusty_v8.a"
+	$(Q)echo "✓ Binding file created at $(INSTALL_ETC_DIR)/src_binding.rs"
+
+# Installs hello_nanvix example binary
+install-hello_nanvix: all-hello_nanvix $(INSTALL_DIR)
+	$(Q)echo "=== Installing hello_nanvix example ==="
+	$(Q)$(MKDIR) "$(INSTALL_BIN_DIR)"
+	$(Q)test -f "$(HELLO_NANVIX_BINARY)" || (echo "Error: $(HELLO_NANVIX_BINARY) not found" && exit 1)
+	$(Q)$(CP) "$(HELLO_NANVIX_BINARY)" "$(INSTALL_BIN_DIR)/"
+	$(Q)echo "✓ hello_nanvix installed at $(INSTALL_BIN_DIR)/hello_nanvix"
 
 # Cleans all build artifact.
 clean:


### PR DESCRIPTION
This pull request refactors the build and installation process for Nanvix artifacts, improving organization and clarity in both the CI workflow and the `Makefile`. The main changes include introducing a unified `install` target, reorganizing installed files into dedicated directories, and updating the CI workflow to use the new installation process.

**Build and Installation Process Improvements:**

* Added a unified `install` target in the `Makefile` that installs all artifacts by invoking both `install-rusty_v8` and the new `install-hello_nanvix` targets, streamlining the installation process.
* Reorganized installation directories by introducing `INSTALL_LIB_DIR`, `INSTALL_BIN_DIR`, and `INSTALL_ETC_DIR`. Artifacts are now installed into these specific subdirectories for better separation and clarity.
* Updated the installation commands so that the static library and binding file are placed in `lib` and `etc` directories, respectively, and the `hello_nanvix` binary is installed in the `bin` directory.
* Added help documentation for the new targets in the `Makefile` to inform users about the updated install process.

**CI Workflow Updates:**

* Updated the CI workflow in `.github/workflows/ci-nanvix.yml` to use the new unified `install` target instead of the previous `install-rusty_v8`, ensuring all artifacts are installed during CI runs. [[1]](diffhunk://#diff-726c1d0c4e52ac1b433ae0975cd5c0daaf3a9a347b5aaba988f1aa73e26c402dL116-R116) [[2]](diffhunk://#diff-726c1d0c4e52ac1b433ae0975cd5c0daaf3a9a347b5aaba988f1aa73e26c402dL129-R129)