### PR TITLE
ci: add concurrency group to cancel duplicate workflow runs

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -18,6 +18,10 @@ permissions:
   actions: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}
+  cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
+
 jobs:
   # Extract Nanvix SHA once - all matrix builds use the same Nanvix release
   get-nanvix-info:


### PR DESCRIPTION
Add a `concurrency` block to the Nanvix CI workflow so that multiple dispatches targeting the same branch cancel in-flight runs, keeping only the latest. This matches the pattern already used in bzip2's workflow.